### PR TITLE
Fixes to Instruction union

### DIFF
--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -75,29 +75,29 @@ namespace mips_emulator {
         };
 
         PACKED(struct General {
-            uint32_t op : 6;
             uint32_t reserved : 26;
+            uint32_t op : 6;
         });
 
         PACKED(struct RType {
-            uint32_t zero : 6;
-            uint32_t rs : 5;
-            uint32_t rt : 5;
-            uint32_t rd : 5;
-            uint32_t shamt : 5;
             uint32_t func : 6;
+            uint32_t shamt : 5;
+            uint32_t rd : 5;
+            uint32_t rt : 5;
+            uint32_t rs : 5;
+            uint32_t zero : 6;
         });
 
         PACKED(struct IType {
-            uint32_t op : 6;
-            uint32_t rs : 5;
-            uint32_t rt : 5;
             uint32_t imm : 16;
+            uint32_t rt : 5;
+            uint32_t rs : 5;
+            uint32_t op : 6;
         });
 
         PACKED(struct JType {
-            uint32_t op : 6;
             uint32_t address : 26;
+            uint32_t op : 6;
         });
 
         // Make sure internal structs are the same size
@@ -110,7 +110,7 @@ namespace mips_emulator {
         static_assert(sizeof(JType) == 4,
                       "Instruction::JType bitfield is not 4 bytes in size");
 
-        // I-Type
+        // R-Type
         Instruction(const Func func, const RegisterName rd,
                     const RegisterName rs, const RegisterName rt,
                     const uint8_t shift_amount = 0) {

--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -125,8 +125,8 @@ namespace mips_emulator {
         }
 
         // I-Type
-        Instruction(const ITypeOpcode opcode, const RegisterName rs,
-                    const RegisterName rt, const uint16_t immediate) {
+        Instruction(const ITypeOpcode opcode, const RegisterName rt,
+                    const RegisterName rs, const uint16_t immediate) {
             itype.op = static_cast<uint8_t>(opcode);
             itype.rt = static_cast<uint8_t>(rt);
             itype.rs = static_cast<uint8_t>(rs);

--- a/tests/executor.cpp
+++ b/tests/executor.cpp
@@ -85,19 +85,19 @@ TEMPLATE_TEST_CASE("or", "[Executor]", RegisterFile32, RegisterFile64) {
 }
 
 TEMPLATE_TEST_CASE("addi", "[Executor]", RegisterFile32, RegisterFile64) {
-	SECTION("Positive numbers") {
-		using Address = typename TestType::Unsigned;
-		TestType reg_file;
-		Address pc = 0;
+    SECTION("Positive numbers") {
+        using Address = typename TestType::Unsigned;
+        TestType reg_file;
+        Address pc = 0;
 
-		reg_file.set_unsigned(RegisterName::e_t0, 100202);
+        reg_file.set_unsigned(RegisterName::e_t1, 100202);
 
-		Instruction instr(IOp::e_addi, RegisterName::e_t0, RegisterName::e_t1,
-			22020);
+        Instruction instr(IOp::e_addi, RegisterName::e_t0, RegisterName::e_t1,
+                          22020);
 
-		const bool no_error = Executor::handle_itype_instr(instr, pc, reg_file);
-		REQUIRE(no_error);
+        const bool no_error = Executor::handle_itype_instr(instr, pc, reg_file);
+        REQUIRE(no_error);
 
-		REQUIRE(reg_file.get(RegisterName::e_t1).u == 122222);
-	}
+        REQUIRE(reg_file.get(RegisterName::e_t0).u == 122222);
+    }
 }

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -1,7 +1,42 @@
 #include "mips-emulator/instruction.hpp"
+#include "mips-emulator/register_name.hpp"
 
 #include <catch2/catch.hpp>
 
 using namespace mips_emulator;
 
-// TODO: Write tests for instruction union
+using Func = Instruction::Func;
+using IOp = Instruction::ITypeOpcode;
+using JOp = Instruction::JTypeOpcode;
+
+TEST_CASE("R-Type instruction", "[Instruction]") {
+    SECTION("add - zero registers") {
+        const Instruction instr(Func::e_add, RegisterName::e_0,
+                                RegisterName::e_0, RegisterName::e_0);
+
+        REQUIRE(instr.raw == 0x20);
+    }
+
+    SECTION("add - non zero registers") {
+        const Instruction instr(Func::e_add, RegisterName::e_t0,
+                                RegisterName::e_t5, RegisterName::e_a0);
+
+        REQUIRE(instr.raw == 0x01a44020);
+    }
+}
+
+TEST_CASE("I-Type instruction", "[Instruction]") {
+    SECTION("addi - zero registers and zero imm") {
+        const Instruction instr(IOp::e_addi, RegisterName::e_0,
+                                RegisterName::e_0, 0);
+
+        REQUIRE(instr.raw == 0x20000000);
+    }
+
+    SECTION("addi - non zero registers and imm") {
+        const Instruction instr(IOp::e_addi, RegisterName::e_t0,
+                                RegisterName::e_t5, 0xffff);
+
+        REQUIRE(instr.raw == 0x21a8ffff);
+    }
+}


### PR DESCRIPTION
* The field order in the internal Instruction union structs where in the wrong order. For example the opcode should occupy the most significant bits and not the least significant.
* The order of the rt and rs registers in the IType constructor was reversed. It was changed to better align with the actual MIPS instruction.
* Some tests were added to tests/instruction.cpp.
* A comment was also fixed.