### PR TITLE
Move PC into register file.

### DIFF
--- a/include/mips-emulator/emulator.hpp
+++ b/include/mips-emulator/emulator.hpp
@@ -20,13 +20,11 @@ namespace mips_emulator {
         RegisterFile clone_register_file() const noexcept { return reg_file; }
 
         [[nodiscard]] bool step() noexcept {
-            return Executor::step(reg_file, memory, pc);
+            return Executor::step(reg_file, memory);
         }
 
     private:
         RegisterFile reg_file;
         Memory memory;
-
-        Address pc;
     };
 } // namespace mips_emulator

--- a/include/mips-emulator/register_file.hpp
+++ b/include/mips-emulator/register_file.hpp
@@ -27,6 +27,10 @@ namespace mips_emulator {
         static constexpr uint8_t REGISTER_COUNT = 32;
         static constexpr uint8_t INDEX_MASK = REGISTER_COUNT - 1;
 
+        Unsigned get_pc() const noexcept { return pc; }
+        void set_pc(Unsigned new_pc) noexcept { pc = new_pc; }
+        void inc_pc() noexcept { return pc += 4; }
+
         Register get(const RegisterName reg) const noexcept {
             return get(static_cast<uint8_t>(reg));
         }
@@ -67,6 +71,7 @@ namespace mips_emulator {
         }
 
     private:
+        Unsigned pc = 0;
         Register regs[REGISTER_COUNT] = {};
     };
 

--- a/tests/executor.cpp
+++ b/tests/executor.cpp
@@ -14,7 +14,6 @@ TEMPLATE_TEST_CASE("add", "[Executor]", RegisterFile32, RegisterFile64) {
     SECTION("Positive numbers") {
         using Address = typename TestType::Unsigned;
         TestType reg_file;
-        Address pc = 0;
 
         reg_file.set_signed(RegisterName::e_t0, 1);
         reg_file.set_signed(RegisterName::e_t1, 5);
@@ -22,7 +21,7 @@ TEMPLATE_TEST_CASE("add", "[Executor]", RegisterFile32, RegisterFile64) {
         Instruction instr(Func::e_add, RegisterName::e_t2, RegisterName::e_t0,
                           RegisterName::e_t1);
 
-        const bool no_error = Executor::handle_rtype_instr(instr, pc, reg_file);
+        const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t2).s == 6);
@@ -33,7 +32,6 @@ TEMPLATE_TEST_CASE("sub", "[Executor]", RegisterFile32, RegisterFile64) {
     SECTION("Positive numbers") {
         using Address = typename TestType::Unsigned;
         TestType reg_file;
-        Address pc = 0;
 
         reg_file.set_signed(RegisterName::e_t0, 10);
         reg_file.set_signed(RegisterName::e_t1, 1);
@@ -41,13 +39,13 @@ TEMPLATE_TEST_CASE("sub", "[Executor]", RegisterFile32, RegisterFile64) {
         Instruction instr(Func::e_sub, RegisterName::e_t2, RegisterName::e_t0,
                           RegisterName::e_t1);
 
-        const bool no_error = Executor::handle_rtype_instr(instr, pc, reg_file);
+        const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t2).s == 9);
     }
 
-	SECTION("Negative numbers") {
+    SECTION("Negative numbers") {
         using Address = typename TestType::Unsigned;
         TestType reg_file;
         Address pc = 0;
@@ -58,7 +56,7 @@ TEMPLATE_TEST_CASE("sub", "[Executor]", RegisterFile32, RegisterFile64) {
         Instruction instr(Func::e_sub, RegisterName::e_t2, RegisterName::e_t0,
                           RegisterName::e_t1);
 
-        const bool no_error = Executor::handle_rtype_instr(instr, pc, reg_file);
+        const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t2).s == 2);
@@ -66,38 +64,36 @@ TEMPLATE_TEST_CASE("sub", "[Executor]", RegisterFile32, RegisterFile64) {
 }
 
 TEMPLATE_TEST_CASE("or", "[Executor]", RegisterFile32, RegisterFile64) {
-	SECTION("Positive numbers") {
-		using Address = typename TestType::Unsigned;
-		TestType reg_file;
-		Address pc = 0;
+    SECTION("Positive numbers") {
+        using Address = typename TestType::Unsigned;
+        TestType reg_file;
 
-		reg_file.set_unsigned(RegisterName::e_t0, 0b1); // 1
-		reg_file.set_unsigned(RegisterName::e_t1, 0b110); // 6
+        reg_file.set_unsigned(RegisterName::e_t0, 0b1);   // 1
+        reg_file.set_unsigned(RegisterName::e_t1, 0b110); // 6
 
-		Instruction instr(Func::e_or, RegisterName::e_t2, RegisterName::e_t0,
-				RegisterName::e_t1);
+        Instruction instr(Func::e_or, RegisterName::e_t2, RegisterName::e_t0,
+                          RegisterName::e_t1);
 
-		const bool no_error = Executor::handle_rtype_instr(instr, pc, reg_file);
-		REQUIRE(no_error);
+        const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
+        REQUIRE(no_error);
 
-		REQUIRE(reg_file.get(RegisterName::e_t2).u == 0b111); // 7
-	}
+        REQUIRE(reg_file.get(RegisterName::e_t2).u == 0b111); // 7
+    }
 }
 
 TEMPLATE_TEST_CASE("addi", "[Executor]", RegisterFile32, RegisterFile64) {
-	SECTION("Positive numbers") {
-		using Address = typename TestType::Unsigned;
-		TestType reg_file;
-		Address pc = 0;
+    SECTION("Positive numbers") {
+        using Address = typename TestType::Unsigned;
+        TestType reg_file;
 
-		reg_file.set_unsigned(RegisterName::e_t0, 100202);
+        reg_file.set_unsigned(RegisterName::e_t0, 100202);
 
-		Instruction instr(IOp::e_addi, RegisterName::e_t0, RegisterName::e_t1,
-			22020);
+        Instruction instr(IOp::e_addi, RegisterName::e_t0, RegisterName::e_t1,
+                          22020);
 
-		const bool no_error = Executor::handle_itype_instr(instr, pc, reg_file);
-		REQUIRE(no_error);
+        const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+        REQUIRE(no_error);
 
-		REQUIRE(reg_file.get(RegisterName::e_t1).u == 122222);
-	}
+        REQUIRE(reg_file.get(RegisterName::e_t1).u == 122222);
+    }
 }


### PR DESCRIPTION
This will make it so all the non memory state is contained withing the register file instead of being split up in between the emulator and the register file. This will also make potential bounds checking easier to implement everywhere.