### PR TITLE
All non-mem itype instrs

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -100,12 +100,58 @@ namespace mips_emulator {
             using IOp = Instruction::ITypeOpcode;
 
             const Register rs = reg_file.get(instr.rtype.rs);
+            const Register rt = reg_file.get(instr.rtype.rt);
+
+            const auto sign_ext_imm = [](const typename RegisterFile::Unsigned imm) {
+                const typename RegisterFile::Unsigned ext = ( ~((typename RegisterFile::Unsigned) 0)) << 16;
+                return ((ext * ((imm >> 15) & 1)) | imm);
+            };
 
             const IOp op = static_cast<IOp>(instr.itype.op);
 
             switch (op) {
+                case IOp::e_beq: {
+                    if (rt.u == rs.u) {
+                        reg_file.set_pc( reg_file.get_pc() + (sign_ext_imm(instr.itype.imm) * 4) + 4);
+                    }
+                    break;
+                }
+                case IOp::e_bne: {
+                    if (rt.u != rs.u) {
+                        reg_file.set_pc( reg_file.get_pc() + (sign_ext_imm(instr.itype.imm) * 4) + 4);
+                    }
+                    break;
+                }
                 case IOp::e_addi: {
-                    reg_file.set_signed(instr.itype.rt, rs.s + instr.itype.imm);
+                    reg_file.set_signed(instr.itype.rt, rs.s + sign_ext_imm(instr.itype.imm));
+                    break;
+                }
+                case IOp::e_addiu: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.u + sign_ext_imm(instr.itype.imm));
+                    break;
+                }
+                case IOp::e_slti: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.s < (typename RegisterFile::Signed) sign_ext_imm(instr.itype.imm));
+                    break;
+                }
+                case IOp::e_sltiu: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.u < sign_ext_imm(instr.itype.imm));
+                    break;
+                }
+                case IOp::e_andi: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.u & instr.itype.imm);
+                    break;
+                }
+                case IOp::e_ori: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.u | instr.itype.imm);
+                    break;
+                }
+                case IOp::e_xori: {
+                    reg_file.set_unsigned(instr.itype.rt, rs.u ^ instr.itype.imm);
+                    break;
+                }
+                case IOp::e_lui: {
+                    reg_file.set_unsigned(instr.itype.rt, (typename RegisterFile::Unsigned) instr.itype.imm << 16);
                     break;
                 }
 

--- a/tests/executor.cpp
+++ b/tests/executor.cpp
@@ -81,19 +81,148 @@ TEMPLATE_TEST_CASE("or", "[Executor]", RegisterFile32, RegisterFile64) {
     }
 }
 
+TEMPLATE_TEST_CASE("beq", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, 7);
+		reg_file.set_unsigned(RegisterName::e_t1, 7);
+		Instruction instr(IOp::e_beq, RegisterName::e_t0, RegisterName::e_t1, 16);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get_pc() == 68);
+
+	}
+}
+
+TEMPLATE_TEST_CASE("bne", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, 7);
+		reg_file.set_unsigned(RegisterName::e_t1, 7);
+
+		Instruction instr(IOp::e_bne, RegisterName::e_t0, RegisterName::e_t1, 16);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get_pc() == 0);
+
+	}
+}
+
 TEMPLATE_TEST_CASE("addi", "[Executor]", RegisterFile32, RegisterFile64) {
     SECTION("Positive numbers") {
         using Address = typename TestType::Unsigned;
         TestType reg_file;
 
-        reg_file.set_unsigned(RegisterName::e_t1, 100202);
+        reg_file.set_unsigned(RegisterName::e_t0, 100202);
 
-        Instruction instr(IOp::e_addi, RegisterName::e_t0, RegisterName::e_t1,
+        Instruction instr(IOp::e_addi, RegisterName::e_t1, RegisterName::e_t0,
                           22020);
 
         const bool no_error = Executor::handle_itype_instr(instr, reg_file);
         REQUIRE(no_error);
 
-        REQUIRE(reg_file.get(RegisterName::e_t0).u == 122222);
+        REQUIRE(reg_file.get(RegisterName::e_t1).u == 122222);
     }
+}
+
+TEMPLATE_TEST_CASE("slti", "[Executor]", RegisterFile32, RegisterFile64) {
+    SECTION("Positive numbers") {
+        using Address = typename TestType::Unsigned;
+        TestType reg_file;
+
+        reg_file.set_signed(RegisterName::e_t0, -5);
+
+        Instruction instr(IOp::e_slti, RegisterName::e_t1, RegisterName::e_t0, 2);
+
+        const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+        REQUIRE(no_error);
+
+        REQUIRE(reg_file.get(RegisterName::e_t1).u == 1);
+    }
+}
+
+TEMPLATE_TEST_CASE("sltiu", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, -5);
+
+		Instruction instr(IOp::e_sltiu, RegisterName::e_t1, RegisterName::e_t0, 2);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get(RegisterName::e_t1).u == 0);
+	}
+}
+
+TEMPLATE_TEST_CASE("andi", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, 0b1100);
+
+		Instruction instr(IOp::e_andi, RegisterName::e_t1, RegisterName::e_t0, 0b1010);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get(RegisterName::e_t1).u == 0b1000);
+	}
+}
+
+TEMPLATE_TEST_CASE("ori", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, 0b1100);
+
+		Instruction instr(IOp::e_ori, RegisterName::e_t1, RegisterName::e_t0, 0b1010);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get(RegisterName::e_t1).u == 0b1110);
+	}
+}
+
+TEMPLATE_TEST_CASE("xori", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		reg_file.set_unsigned(RegisterName::e_t0, 0b1100);
+
+		Instruction instr(IOp::e_xori, RegisterName::e_t1, RegisterName::e_t0, 0b1010);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get(RegisterName::e_t1).u == 0b0110);
+	}
+}
+
+TEMPLATE_TEST_CASE("lui", "[Executor]", RegisterFile32, RegisterFile64) {
+	SECTION("Positive numbers") {
+		using Address = typename TestType::Unsigned;
+		TestType reg_file;
+
+		Instruction instr(IOp::e_lui, RegisterName::e_t1, RegisterName::e_0, 0xbeef);
+
+		const bool no_error = Executor::handle_itype_instr(instr, reg_file);
+		REQUIRE(no_error);
+
+		REQUIRE(reg_file.get(RegisterName::e_t1).u == 0xbeef0000);
+	}
 }


### PR DESCRIPTION
Adds handeling for all the non-mem itype instructions (found in Instruction::ITypeOpcode) and some (very basic) tests.
Fixes #199
Fixes #101
Fixes #17 
Fixes #162 
Fixes #163 
Fixes #129 
Fixes #23 
Fixes #32 
Fixes #40 
