### PR TITLE
First memory implementation (StaticMemory)

### DIFF
--- a/include/mips-emulator/memory_error.hpp
+++ b/include/mips-emulator/memory_error.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+namespace mips_emulator {
+    enum class MemoryError : uint8_t {
+        unaligned_access,
+        out_of_bounds_access,
+    };
+}

--- a/include/mips-emulator/result.hpp
+++ b/include/mips-emulator/result.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace mips_emulator {
+    template <typename Value, typename Error>
+    class Result {
+    public:
+        [[nodiscard]] bool is_error() const { return is_err; }
+
+        [[nodiscard]] Value get_value() const { return value; }
+        [[nodiscard]] Error get_error() const { return error; }
+
+        Result(Value value) {
+            is_err = false;
+            value = value;
+        }
+
+        Result(Error error) {
+            is_err = true;
+            error = error;
+        }
+
+    private:
+        bool is_err;
+        union {
+            Value value;
+            Error error;
+        };
+    };
+
+    template <typename Error>
+    class Result<void, Error> {
+    public:
+        [[nodiscard]] bool is_error() const { return is_err; }
+
+        [[nodiscard]] Error get_error() const { return error; }
+
+        Result() { is_err = false; }
+
+        Result(Error error) {
+            is_err = true;
+            error = error;
+        }
+
+    private:
+        bool is_err;
+        Error error;
+    };
+
+} // namespace mips_emulator

--- a/include/mips-emulator/span.hpp
+++ b/include/mips-emulator/span.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+namespace mips_emulator {
+    template <typename T>
+    class Span {
+    public:
+        Span(T* data, std::size_t size) : data(data), size(size) {}
+
+        T* get_data() noexcept { data; }
+        const T* get_data() const noexcept { data; }
+
+        std::size_t get_size() const noexcept { return size; }
+
+        T& operator[](std::size_t i) { return data[i]; }
+        const T& operator[](std::size_t i) const { return data[i]; }
+
+    private:
+        T* data;
+        std::size_t size;
+    };
+} // namespace mips_emulator

--- a/include/mips-emulator/static_memory.hpp
+++ b/include/mips-emulator/static_memory.hpp
@@ -1,0 +1,108 @@
+#pragma once
+#include "mips-emulator/span.hpp"
+#include "mips-emulator/result.hpp"
+#include "mips-emulator/memory_error.hpp"
+
+#include <memory>
+#include <memory_resource>
+#include <type_traits>
+
+namespace mips_emulator {
+    template <typename Address>
+    struct NullMMIO {};
+
+    template <typename UnsignedWord,
+              template <typename> typename MMIOHandler = NullMMIO>
+    class StaticMemory {
+    public:
+        using Address = UnsignedWord;
+        using Size = UnsignedWord;
+
+        using MMIO = MMIOHandler<Address>;
+
+        StaticMemory(const Size size, MMIO&& mmio,
+                     std::shared_ptr<std::pmr::memory_resource>
+                         memory_resource = nullptr)
+            : memory(size, 0, memory_resource), mmio(mmio) {}
+
+        // NOTE:
+        // This method is deliberately left as non-const because the
+        // MMIOHandler read might not be const, and alter some internal state.
+        template <typename T>
+        Result<T, MemoryError> read(const Address address) {
+            static_assert(sizeof(T) <= sizeof(Address),
+                          "Can't read larger than word size");
+
+            // NOTE: Types of size 1 are always aligned
+            if constexpr (sizeof(T) > 1) {
+                if (!is_aligned<T>(address)) {
+                    return MemoryError::unaligned_access;
+                }
+            }
+
+            // Try to read from MMIO handler
+            if constexpr (std::is_member_function_pointer_v<
+                              decltype(&MMIO::template read<T>)>) {
+                const auto mmio_value = mmio.template read<T>(address);
+                if (mmio_value.has_value()) return mmio_value.value();
+            }
+
+            // NOTE: Bounds check after MMIO, MMIO could have a bigger range
+            if (!is_in_bounds<T>(address)) {
+                return MemoryError::out_of_bounds_access;
+            }
+
+            return *reinterpret_cast<T*>(&memory[address]);
+        }
+
+        template <typename T>
+        Result<void, MemoryError> store(const Address address, const T value) {
+            static_assert(sizeof(T) <= sizeof(Address),
+                          "Can't read larger than word size");
+
+            // NOTE: Types of size 1 are always aligned
+            if constexpr (sizeof(T) > 1) {
+                if (!is_aligned<T>(address)) {
+                    return MemoryError::unaligned_access;
+                }
+            }
+
+            // Try to write to MMIO handler
+            if constexpr (std::is_member_function_pointer_v<
+                              decltype(&MMIO::template store<T>)>) {
+                if (mmio.template store<T>(address, value)) return {};
+            }
+
+            // NOTE: Bounds check after MMIO, MMIO could have a bigger range
+            if (!is_in_bounds<T>(address)) {
+                return MemoryError::out_of_bounds_access;
+            }
+
+            *reinterpret_cast<T*>(&memory[address]) = value;
+
+            return {};
+        }
+
+        Span<uint8_t> get_memory() {
+            return {
+                memory.data(),
+                memory.size(),
+            };
+        }
+
+    private:
+        template <typename T>
+        inline static bool is_aligned(const Address address) {
+            return (address & sizeof(T)) == 0;
+        }
+
+        template <typename T>
+        inline bool is_in_bounds(const Address address) {
+            return (address + sizeof(T)) < memory.size();
+        }
+
+    private:
+        MMIOHandler<Address> mmio;
+        std::pmr::vector<uint8_t> memory;
+    };
+} // namespace mips_emulator


### PR DESCRIPTION
* Adds Result type
* Adds MemoryError enum
* Adds Span type
* Adds StaticMemory memory implementation

This is an attempt at the first implementation of Memory to be used by the emulator. This first attempt has an immutable size.