### PR TITLE
Implement SOP arithmetic instructions

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -32,6 +32,14 @@ namespace mips_emulator {
             }
         }
 
+        // Returns the higher 32 bits of a multiplication
+        template <typename small_t, typename big_t>
+        small_t hi_mul(small_t a, small_t b) {
+            const big_t a64 = static_cast<big_t>(a);
+            const big_t b64 = static_cast<big_t>(b);
+            return static_cast<small_t>((a64 * b64) >> 32);
+        };
+
         template <typename RegisterFile>
         [[nodiscard]] inline static bool
         handle_rtype_instr(const Instruction instr, RegisterFile& reg_file) {
@@ -43,6 +51,13 @@ namespace mips_emulator {
             const Register rt = reg_file.get(instr.rtype.rt);
 
             const Func func = static_cast<Func>(instr.rtype.func);
+
+            // SOP helper function
+            // GPR[rd] <- shamt2 if shamt = 2 else shamt 3.
+            auto sop_set_rd = [&](uint32_t shamt2, uint32_t shamt3) {
+                reg_file.set_signed(instr.rtype.rd,
+                                    instr.rtype.shamt == 2 ? shamt2 : shamt3);
+            };
 
             switch (func) {
                 case Func::e_add: {
@@ -61,12 +76,22 @@ namespace mips_emulator {
                     reg_file.set_unsigned(instr.rtype.rd, rs.u - rt.u);
                     break;
                 }
-                case Func::e_mul: {
-                    reg_file.set_signed(instr.rtype.rd, rs.s * rt.s);
+                case Func::e_sop30: { // Shamt: 2 = mul, 3 = muh
+                    sop_set_rd(rs.s * rt.s,
+                               hi_mul<int32_t, int64_t>(rs.s, rt.s));
                     break;
                 }
-                case Func::e_mulu: {
-                    reg_file.set_unsigned(instr.rtype.rd, rs.u * rt.u);
+                case Func::e_sop31: { // Shamt: 2 = mulu, 3 = muhu
+                    sop_set_rd(rs.u * rt.u,
+                               hi_mul<uint32_t, uint64_t>(rs.u, rt.u));
+                    break;
+                }
+                case Func::e_sop32: { // Shamt: 2 = div, 3 = mod
+                    sop_set_rd(rs.s / rt.s, rs.s % rt.s);
+                    break;
+                }
+                case Func::e_sop33: { // Shamt: 2 = divu, 3 = modu
+                    sop_set_rd(rs.u / rt.u, rs.u % rt.u);
                     break;
                 }
                 case Func::e_and: {

--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -37,8 +37,10 @@ namespace mips_emulator {
             e_addu = 33,
             e_sub = 34,
             e_subu = 35,
-            e_mul = 24,
-            e_mulu = 26,
+            e_sop30 = 0b011000, // SOP30 - shamt: 2 = mul,  3 = muh
+            e_sop31 = 0b011001, // SOP31 - shamt: 2 = mulu, 3 = muhu
+            e_sop32 = 0b011010, // SOP32 - shamt: 2 = div,  3 = mod
+            e_sop33 = 0b011011, // SOP33 - shamt: 2 = divu, 3 = modu
             e_and = 36,
             e_nor = 39,
             e_or = 37,
@@ -174,7 +176,7 @@ namespace mips_emulator {
 
         // Coprocessor 1 structs
         // These are made up names, as I (Emil) couldn't find any specified
-        // type names in the mip32 specifications. 
+        // type names in the mip32 specifications.
         // FPURType is called so because it's similar to R type instructions
         // FPUBType is called so because it does branching.
         // FPUTType is called so because it (T)ransfers to and from the FPU
@@ -185,7 +187,7 @@ namespace mips_emulator {
             uint32_t fs : 5;
             uint32_t ft : 5;
             uint32_t fmt : 5;
-            uint32_t cop1 : 6;           
+            uint32_t cop1 : 6;
         });
 
         PACKED(struct FPUBType {
@@ -251,8 +253,8 @@ namespace mips_emulator {
             jtype.address = address & MASK;
         }
 
-        // No need for FPU register naming since it's just $f[number] 
-        
+        // No need for FPU register naming since it's just $f[number]
+
         // FPU R-Type
         Instruction(const FPURTypeOp op, const uint8_t ft, const uint8_t fs, const uint8_t fd, const FPUFunc func) {
             fpu_rtype.cop1 = static_cast<uint8_t>(COPOpcode::e_cop1);

--- a/tests/executor.cpp
+++ b/tests/executor.cpp
@@ -437,3 +437,103 @@ TEST_CASE("jal", "[Executor]") {
         REQUIRE(reg_file.get(RegisterName::e_ra).u == 0x10beef04);
     }
 }
+
+TEST_CASE("sop30", "[Executor]") {
+    SECTION("mul") {
+        int32_t values[] = {-0x6FF,   0x55,        0x125,    0x7564,
+                            0x523522, -0x7FCCA241, 0x23525,  0x1247,
+                            0xFFFF,   INT32_MAX,   INT32_MIN};
+
+        for (int val1 : values) {
+            for (int val2 : values) {
+                RegisterFile reg_file;
+                reg_file.set_signed(RegisterName::e_t0, val1);
+                reg_file.set_signed(RegisterName::e_t1, val2);
+
+                Instruction instr(Func::e_sop30, RegisterName::e_t0,
+                                  RegisterName::e_t0, RegisterName::e_t1, 2);
+
+                const bool no_error =
+                    Executor::handle_rtype_instr(instr, reg_file);
+                REQUIRE(no_error);
+
+                REQUIRE(reg_file.get(RegisterName::e_t0).s == val1 * val2);
+            }
+        }
+    }
+
+    // Using mars mult mfhi
+    SECTION("muh") {
+        int32_t cases[][3] = {{-0x126373, -0x126373, (int32_t)0x00000152},
+                              {-0x126373, 0xF2A373, (int32_t)0xffffee92},
+                              {0xABC1235, 0xF2A373, (int32_t)0x000a2ca3}};
+
+        for (auto& test : cases) {
+            const int32_t val1 = test[0];
+            const int32_t val2 = test[1];
+            const int32_t res = test[2];
+
+            RegisterFile reg_file;
+            reg_file.set_signed(RegisterName::e_t0, val1);
+            reg_file.set_signed(RegisterName::e_t1, val2);
+
+            Instruction instr(Func::e_sop30, RegisterName::e_t0,
+                              RegisterName::e_t0, RegisterName::e_t1, 3);
+
+            const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
+            REQUIRE(no_error);
+
+            REQUIRE(reg_file.get(RegisterName::e_t0).s == res);
+        }
+    }
+}
+
+TEST_CASE("sop31", "[Executor]") {
+    SECTION("mul") {
+        uint32_t values[] = {0x6FF,    0x55,       0x125,   0x7564,
+                             0x523522, 0x7FCCA241, 0x23525, 0x1247,
+                             0xFFFF,   UINT32_MAX, 0};
+
+        for (int val1 : values) {
+            for (int val2 : values) {
+                RegisterFile reg_file;
+                reg_file.set_unsigned(RegisterName::e_t0, val1);
+                reg_file.set_unsigned(RegisterName::e_t1, val2);
+
+                Instruction instr(Func::e_sop31, RegisterName::e_t0,
+                                  RegisterName::e_t0, RegisterName::e_t1, 2);
+
+                const bool no_error =
+                    Executor::handle_rtype_instr(instr, reg_file);
+                REQUIRE(no_error);
+
+                REQUIRE(reg_file.get(RegisterName::e_t0).u == val1 * val2);
+            }
+        }
+    }
+
+    // Using mars multu mfhi
+    SECTION("muh") {
+        uint32_t cases[][3] = {{0x126373, 0x126373, 0x00000152},
+                               {0x126373, 0xF2A373, 0x0000116d},
+                               {0xABC1235, 0xF2A373, 0x000a2ca3}};
+
+        for (auto& test : cases) {
+            const int32_t val1 = test[0];
+            const int32_t val2 = test[1];
+            const int32_t res = test[2];
+
+            RegisterFile reg_file;
+            reg_file.set_signed(RegisterName::e_t0, val1);
+            reg_file.set_signed(RegisterName::e_t1, val2);
+
+            Instruction instr(Func::e_sop30, RegisterName::e_t0,
+                              RegisterName::e_t0, RegisterName::e_t1, 3);
+
+            const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
+            REQUIRE(no_error);
+
+            REQUIRE(reg_file.get(RegisterName::e_t0).u == res);
+        }
+    }
+}


### PR DESCRIPTION
Includes: MUL MUH MULH MUHU DIV DIVU MOD and MODU.

Where the 'H' instructions give the higher 32 bits of the multiplication

These are new in MIPS32 Release 6 and replaces the HI/LO registers.

Fixes: 
#122 
#64 

