### PR TITLE
Load/Store Halfwords

### DIFF
--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -111,6 +111,8 @@ namespace mips_emulator {
             e_lw = 35,
             e_sb = 40,
             e_sw = 43,
+            e_lh = 0b100001,
+            e_sh = 0b101001,
         };
 
         enum class JTypeOpcode : uint8_t {


### PR DESCRIPTION
Adds LH and SH instructions, as well as refactoring the memory handle_itype_instr to be less copypasty. 

Closes #92 #156 