### PR TITLE
Execute from mem

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -344,8 +344,11 @@ namespace mips_emulator {
                                               Memory& memory) {
             using Type = Instruction::Type;
 
-            const Instruction instr =
-                memory.template read<Instruction>(reg_file.get_pc());
+            auto read_result =
+                memory.template read<uint32_t>(reg_file.get_pc());
+
+            if (read_result.is_error()) return false;
+            const auto instr = Instruction(read_result.get_value());
 
             reg_file.inc_pc();
 

--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -282,6 +282,8 @@ namespace mips_emulator {
             fpu_ttype.zero = 0;
         }
 
+        // raw
+        Instruction(const uint32_t value) { raw = value; }
 
         inline Type get_type() const {
             if (general.op == static_cast<uint8_t>(COPOpcode::e_cop1)) {


### PR DESCRIPTION
- adds a "raw" constructor for Instruction, that takes a uint32.
- fixes memory error handeling for Executor::step function
- a couple of tests for Executor::step

("accepting all" in merge SHOULD work)