### PR TITLE
Change memory and executor to work on plugin.

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -169,7 +169,8 @@ namespace mips_emulator {
             return true;
         }
 
-        const uint32_t sign_ext_imm(const uint32_t imm) {
+        template <typename T>
+        const uint32_t sign_ext_imm(const T imm) {
             const uint32_t ext = (~0U) << 16;
             return ((ext * ((imm >> 15) & 1)) | imm);
         }

--- a/include/mips-emulator/runtime_static_memory.hpp
+++ b/include/mips-emulator/runtime_static_memory.hpp
@@ -9,9 +9,9 @@ namespace mips_emulator {
     public:
         RuntimeStaticMemory(const uint32_t size,
                             std::shared_ptr<MMIOHandler> mmio = nullptr)
-            : memory(new uint8_t[size]),
-              size(size), Memory<RuntimeStaticMemory<MMIOHandler>, MMIOHandler>(
-                              std::move(mmio)) {}
+            : Memory<RuntimeStaticMemory<MMIOHandler>, MMIOHandler>(
+                  std::move(mmio)),
+              memory(new uint8_t[size]), size(size) {}
 
         uint8_t* get_memory() { return memory; }
         uint32_t get_size() const { return size; }

--- a/include/mips-emulator/span.hpp
+++ b/include/mips-emulator/span.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <cstddef>
 
 namespace mips_emulator {
     template <typename T>


### PR DESCRIPTION
[prepare memory for plugin](https://github.com/pvk-2022-2/mips-emulator/pull/229/commits/3306dab5a5cf58a2609d46a7a3cc9e8976d84ebd)

# DOES NOT USE RAW POINTERS

instead, makes sign_ext_imm a template to avoid multiply include.

changes constructor order in runtime_static_memory to avoid warning.

includes <cstddef> in span because size_t.