### PR TITLE
Fix compile warning in step func.

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -419,6 +419,8 @@ namespace mips_emulator {
                 }
                 case Type::e_special3_rtype:
                     return handle_special3_rtype_instr(instr, reg_file);
+
+                default: return false;
             }
         }
     }; // namespace Executor


### PR DESCRIPTION
Fixes executor.hpp:423:9: warning: control reaches end of non-void function