### PR TITLE
Fix Relative Branch/Jump instructions

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -96,7 +96,7 @@ namespace mips_emulator {
                 }
                 case Func::e_jalr: {
                     reg_file.set_unsigned(RegisterName::e_ra,
-                                          reg_file.get_pc() + 4);
+                                          reg_file.get_pc());
                     reg_file.delayed_branch(rs.u);
                     break;
                 }
@@ -189,7 +189,7 @@ namespace mips_emulator {
                 case IOp::e_beq: {
                     if (rt.u == rs.u) {
                         reg_file.delayed_branch(
-                            reg_file.get_pc() + 4 +
+                            reg_file.get_pc() +
                             (sign_ext_imm(instr.itype.imm) * 4));
                     }
                     break;
@@ -197,7 +197,7 @@ namespace mips_emulator {
                 case IOp::e_bne: {
                     if (rt.u != rs.u) {
                         reg_file.delayed_branch(
-                            reg_file.get_pc() + 4 +
+                            reg_file.get_pc() +
                             (sign_ext_imm(instr.itype.imm) * 4));
                     }
                     break;
@@ -335,7 +335,7 @@ namespace mips_emulator {
                 }
                 case JOp::e_jal: {
                     reg_file.set_unsigned(RegisterName::e_ra,
-                                          reg_file.get_pc() + 4);
+                                          reg_file.get_pc());
                     reg_file.delayed_branch(jta);
                     break;
                 }

--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -388,14 +388,14 @@ namespace mips_emulator {
                 case ROp::e_seb: {
                     // Sign-extend Byte
                     reg_file.set_unsigned(instr.special3_rtype.rd,
-                                          (((~0) << 8) * ((rt.u >> 7) & 1)) |
+                                          (((~0U) << 8) * ((rt.u >> 7) & 1)) |
                                               (rt.u & 0xFF));
                     break;
                 }
                 case ROp::e_seh: {
                     // Sign-extend Halfword
                     reg_file.set_unsigned(instr.special3_rtype.rd,
-                                          (((~0) << 16) * ((rt.u >> 15) & 1)) |
+                                          (((~0U) << 16) * ((rt.u >> 15) & 1)) |
                                               (rt.u & 0xFFFF));
                     break;
                 }

--- a/tests/executor.cpp
+++ b/tests/executor.cpp
@@ -93,10 +93,11 @@ TEST_CASE("beq", "[Executor]") {
         Instruction instr(IOp::e_beq, RegisterName::e_t0, RegisterName::e_t1,
                           16);
 
+        reg_file.inc_pc();  // emulate step
         const bool no_error = Executor::handle_itype_instr(instr, reg_file);
         REQUIRE(no_error);
 
-        REQUIRE(reg_file.get_pc() == 0);
+        REQUIRE(reg_file.get_pc() == 4);
 
         reg_file.update_pc(); // moves past delays slot
 
@@ -112,14 +113,15 @@ TEST_CASE("beq", "[Executor]") {
         Instruction instr(IOp::e_beq, RegisterName::e_t0, RegisterName::e_t1,
                           16);
 
+        reg_file.inc_pc();  // emulate step
         const bool no_error = Executor::handle_itype_instr(instr, reg_file);
         REQUIRE(no_error);
 
-        REQUIRE(reg_file.get_pc() == 0);
+        REQUIRE(reg_file.get_pc() == 4);
 
         reg_file.update_pc(); // moves past delays slot
 
-        REQUIRE(reg_file.get_pc() == 4);
+        REQUIRE(reg_file.get_pc() == 8);
     }
 }
 
@@ -134,10 +136,11 @@ TEST_CASE("bne", "[Executor]") {
         Instruction instr(IOp::e_bne, RegisterName::e_t0, RegisterName::e_t1,
                           16);
 
+        reg_file.inc_pc();  // Emulate step
         const bool no_error = Executor::handle_itype_instr(instr, reg_file);
         REQUIRE(no_error);
 
-        REQUIRE(reg_file.get_pc() == 0);
+        REQUIRE(reg_file.get_pc() == 4);
 
         reg_file.update_pc(); // moves past delays slot
 
@@ -154,14 +157,15 @@ TEST_CASE("bne", "[Executor]") {
         Instruction instr(IOp::e_bne, RegisterName::e_t0, RegisterName::e_t1,
                           16);
 
+        reg_file.inc_pc();  // Emulate step
         const bool no_error = Executor::handle_itype_instr(instr, reg_file);
         REQUIRE(no_error);
 
-        REQUIRE(reg_file.get_pc() == 0);
+        REQUIRE(reg_file.get_pc() == 4);
 
         reg_file.update_pc(); // moves past delays slot
 
-        REQUIRE(reg_file.get_pc() == 4);
+        REQUIRE(reg_file.get_pc() == 8);
     }
 }
 
@@ -476,6 +480,7 @@ TEST_CASE("j", "[Executor]") {
 
         Instruction instr(JOp::e_j, 0x003fc);
 
+        reg_file.inc_pc();  // emulate step
         const bool no_error = Executor::handle_jtype_instr(instr, reg_file);
         REQUIRE(no_error);
 
@@ -493,6 +498,7 @@ TEST_CASE("jal", "[Executor]") {
 
         Instruction instr(JOp::e_jal, 0x003fc);
 
+        reg_file.update_pc(); // emulate step
         const bool no_error = Executor::handle_jtype_instr(instr, reg_file);
         REQUIRE(no_error);
 
@@ -514,6 +520,7 @@ TEST_CASE("jr", "[Executor]") {
     Instruction instr(Func::e_jr, RegisterName::e_0, RegisterName::e_t0,
                       RegisterName::e_0);
 
+    reg_file.update_pc(); // emulate step
     const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
     REQUIRE(no_error);
 
@@ -533,6 +540,7 @@ TEST_CASE("jalr", "[Executor]") {
     Instruction instr(Func::e_jalr, RegisterName::e_0, RegisterName::e_t0,
                       RegisterName::e_0);
 
+    reg_file.update_pc(); // emulate step
     const bool no_error = Executor::handle_rtype_instr(instr, reg_file);
     REQUIRE(no_error);
 


### PR DESCRIPTION
+4 is already accounted four because of step.

testing was fixed by adding a fictional step before running an instr,
instead of having the resulting values assume that the no step exist.