### PR TITLE
Refactored Instruction::get_type method

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -565,7 +565,11 @@ namespace mips_emulator {
 
             reg_file.update_pc();
 
-            switch (instr.get_type()) {
+            const auto instr_type = instr.get_type();
+
+            if (instr_type.is_error()) return false;
+
+            switch (instr_type.get_value()) {
                 case Type::e_rtype: return handle_rtype_instr(instr, reg_file);
                 case Type::e_itype:
                     return handle_itype_instr(instr, reg_file, memory);

--- a/include/mips-emulator/result.hpp
+++ b/include/mips-emulator/result.hpp
@@ -27,6 +27,25 @@ namespace mips_emulator {
         };
     };
 
+    template <typename Value>
+    class Result<Value, void> {
+    public:
+        [[nodiscard]] bool is_error() const { return is_err; }
+
+        [[nodiscard]] Value get_value() const { return value; }
+
+        Result() { is_err = true; }
+
+        Result(Value val) {
+            is_err = false;
+            value = val;
+        }
+
+    private:
+        bool is_err;
+        Value value;
+    };
+
     template <typename Error>
     class Result<void, Error> {
     public:

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -5,9 +5,15 @@
 
 using namespace mips_emulator;
 
+using Type = Instruction::Type;
 using Func = Instruction::Func;
 using IOp = Instruction::ITypeOpcode;
 using JOp = Instruction::JTypeOpcode;
+
+bool instr_type_matches(Instruction instr, Type type) {
+    const auto instr_type = instr.get_type();
+    return !instr_type.is_error() && instr_type.get_value() == type;
+}
 
 TEST_CASE("R-Type instruction", "[Instruction]") {
 
@@ -26,7 +32,7 @@ TEST_CASE("R-Type instruction", "[Instruction]") {
             const auto instr = Instruction(
                 f, RegisterName::e_0, RegisterName::e_0, RegisterName::e_0);
 
-            REQUIRE(instr.get_type() == Instruction::Type::e_rtype);
+            REQUIRE(instr_type_matches(instr, Instruction::Type::e_rtype));
         }
     }
 
@@ -34,7 +40,7 @@ TEST_CASE("R-Type instruction", "[Instruction]") {
         const Instruction instr(Func::e_add, RegisterName::e_0,
                                 RegisterName::e_0, RegisterName::e_0);
 
-        REQUIRE(instr.get_type() == Instruction::Type::e_rtype);
+        REQUIRE(instr_type_matches(instr, Instruction::Type::e_rtype));
         REQUIRE(instr.raw == 0x20);
     }
 
@@ -42,7 +48,7 @@ TEST_CASE("R-Type instruction", "[Instruction]") {
         const Instruction instr(Func::e_add, RegisterName::e_t0,
                                 RegisterName::e_t5, RegisterName::e_a0);
 
-        REQUIRE(instr.get_type() == Instruction::Type::e_rtype);
+        REQUIRE(instr_type_matches(instr, Instruction::Type::e_rtype));
         REQUIRE(instr.raw == 0x01a44020);
     }
 
@@ -102,12 +108,13 @@ TEST_CASE("I-Type instruction", "[Instruction]") {
             const auto instr_zero =
                 Instruction(i, RegisterName::e_0, RegisterName::e_0, 0);
 
-            REQUIRE(instr_zero.get_type() == Instruction::Type::e_itype);
+            REQUIRE(instr_type_matches(instr_zero, Instruction::Type::e_itype));
 
             const auto instr_non_zero =
                 Instruction(i, RegisterName::e_t0, RegisterName::e_t5, 0xffff);
 
-            REQUIRE(instr_non_zero.get_type() == Instruction::Type::e_itype);
+            REQUIRE(
+                instr_type_matches(instr_non_zero, Instruction::Type::e_itype));
         }
     }
 
@@ -134,7 +141,7 @@ TEST_CASE("J-Type instruction", "[Instruction]") {
         for (auto const j : jops) {
             const auto instr = Instruction(j, 0);
 
-            REQUIRE(instr.get_type() == Instruction::Type::e_jtype);
+            REQUIRE(instr_type_matches(instr, Instruction::Type::e_jtype));
         }
     }
 }
@@ -150,7 +157,7 @@ TEST_CASE("FPU R Type", "[Instruction]") {
                      R::e_fmt_l, R::e_cmp_condn_s, R::e_cmp_condn_d};
         for (auto const v : instr) {
             const auto inst = Instruction(v, 0, 2, 3, Func::e_floor_l);
-            REQUIRE(inst.get_type() == Type::e_fpu_rtype);
+            REQUIRE(instr_type_matches(inst, Type::e_fpu_rtype));
         }
     }
 
@@ -178,7 +185,7 @@ TEST_CASE("FPU T Type", "[Instruction]") {
         T instr[] = {T::e_cf, T::e_ct, T::e_mf, T::e_mfh, T::e_mt, T::e_mth};
         for (auto const v : instr) {
             const auto inst = Instruction(v, RegisterName::e_k0, 0);
-            REQUIRE(inst.get_type() == Type::e_fpu_ttype);
+            REQUIRE(instr_type_matches(inst, Type::e_fpu_ttype));
         }
     }
 
@@ -201,7 +208,7 @@ TEST_CASE("FPU B Type", "[Instruction]") {
         B instr[] = {B::e_bc1eqz, B::e_bc1nez};
         for (auto const v : instr) {
             const auto inst = Instruction(v, 31, 25);
-            REQUIRE(inst.get_type() == Type::e_fpu_btype);
+            REQUIRE(instr_type_matches(inst, Type::e_fpu_btype));
         }
     }
 }
@@ -215,7 +222,7 @@ TEST_CASE("Special3 Type", "[Instruction]") {
         // EXT, rt, rs, msbd(rd), lsb(extra), func
         const auto inst =
             Instruction(R::e_ext, 0, 1, RegisterName::e_t0, RegisterName::e_t1);
-        REQUIRE(inst.get_type() == Type::e_special3_rtype);
+        REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
     }
 
     // Note, the size parameter is stored as size-1 in the machine instruction
@@ -229,7 +236,7 @@ TEST_CASE("Special3 Type", "[Instruction]") {
         // INS, rt, rs, msb(rd), lsb(extra), func
         const auto inst =
             Instruction(R::e_ins, 0, 0, RegisterName::e_t0, RegisterName::e_t1);
-        REQUIRE(inst.get_type() == Type::e_special3_rtype);
+        REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
     }
 
     // Note, the size parameter is stored as size-1 in the machine instruction
@@ -245,7 +252,7 @@ TEST_CASE("Special3 Type", "[Instruction]") {
         for (auto const v : instr) {
             const auto inst = Instruction(R::e_bshfl, v, RegisterName::e_t0,
                                           RegisterName::e_t1);
-            REQUIRE(inst.get_type() == Type::e_special3_rtype);
+            REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
         }
     }
 
@@ -276,7 +283,6 @@ TEST_CASE("Special3 Type", "[Instruction]") {
 
 TEST_CASE("Regimm I Type", "[Instruction]") {
     using Type = Instruction::Type;
-    using I = Instruction::RegimmOpcode;
     using IOp = Instruction::RegimmITypeOp;
 
     SECTION("get_type") {
@@ -284,7 +290,7 @@ TEST_CASE("Regimm I Type", "[Instruction]") {
 
         for (auto const v : instr) {
             const auto inst = Instruction(v, RegisterName::e_t0, 3);
-            REQUIRE(inst.get_type() == Type::e_regimm_itype);
+            REQUIRE(instr_type_matches(inst, Type::e_regimm_itype));
         }
     }
 


### PR DESCRIPTION
Closes #249 

Refactors the get_type method in order to be more easily extended. It now uses one switch statement instead of trying to be clever, and it returns a result type instead of returning the IType type for unknown instructions.