### PR TITLE
Refactored Special3 instructions

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -409,111 +409,111 @@ namespace mips_emulator {
 
         template <typename RegisterFile>
         [[nodiscard]] inline static bool
-        handle_special3_rtype_instr(const Instruction instr,
-                                    RegisterFile& reg_file) {
+        handle_special3_type_bshfl_instr(const Instruction instr,
+                                         RegisterFile& reg_file) {
             using Register = typename RegisterFile::Register;
-            using RFunc = Instruction::Special3Func;
+            using Func = Instruction::Special3BSHFLFunc;
 
-            const Register rt = reg_file.get(instr.special3_rtype.rt);
+            const Register rt = reg_file.get(instr.special3_type_bshfl.rt);
 
-            // Switch on Func since instruction layouts are different
-            switch (static_cast<RFunc>(instr.special3_rtype.func)) {
-                case RFunc::e_bshfl: {
-                    // BSHFL, zero(rs), rt, rd, rop(extra), func
-                    using ROp = Instruction::Special3BSHFLTypeOp;
-                    const ROp op = static_cast<ROp>(instr.special3_rtype.extra);
-                    switch (op) {
-                        case ROp::e_bitswap: {
-                            // Swaps (reverses) bits in a byte
-                            // Example: 0b11001000 -> 0b00010011
-                            const auto reverse_byte_bits = [&](uint8_t val) {
-                                val = ((val >> 1) & 0x55) | ((val & 0x55) << 1);
-                                val = ((val >> 2) & 0x33) | ((val & 0x33) << 2);
-                                val = ((val >> 4) & 0x0f) | ((val & 0x0f) << 4);
-                                return val;
-                            };
+            const auto func = static_cast<Func>(instr.special3_type_bshfl.func);
 
-                            // Swaps (reverses) the bits for each byte
-                            uint32_t result = 0;
-                            for (int i = 0; i < sizeof(uint32_t); i++)
-                                result |= reverse_byte_bits((rt.u >> i * 8))
-                                          << (i * 8);
+            switch (func) {
+                case Func::e_bitswap: {
+                    // Swaps (reverses) bits in a byte
+                    // Example: 0b11001000 -> 0b00010011
+                    const auto reverse_byte_bits = [&](uint8_t val) {
+                        val = ((val >> 1) & 0x55) | ((val & 0x55) << 1);
+                        val = ((val >> 2) & 0x33) | ((val & 0x33) << 2);
+                        val = ((val >> 4) & 0x0f) | ((val & 0x0f) << 4);
+                        return val;
+                    };
 
-                            reg_file.set_unsigned(instr.special3_rtype.rd,
-                                                  result);
+                    // Swaps (reverses) the bits for each byte
+                    uint32_t result = 0;
+                    for (int i = 0; i < sizeof(uint32_t); i++)
+                        result |= reverse_byte_bits((rt.u >> i * 8)) << (i * 8);
 
-                            break;
-                        }
-                        case ROp::e_wsbh: {
-                            // Word Swap Bytes Within Halfwords
-                            reg_file.set_unsigned(
-                                instr.special3_rtype.rd,
-                                ((rt.u & 0xFF) << 8) | ((rt.u & 0xFF00) >> 8) |
-                                    ((rt.u & 0xFF0000) << 8) |
-                                    ((rt.u & 0xFF000000) >> 8));
-                            break;
-                        }
-                        case ROp::e_seb: {
-                            // Sign-extend Byte
-                            reg_file.set_unsigned(
-                                instr.special3_rtype.rd,
-                                (((~0U) << 8) * ((rt.u >> 7) & 1)) |
-                                    (rt.u & 0xFF));
-                            break;
-                        }
-                        case ROp::e_seh: {
-                            // Sign-extend Halfword
-                            reg_file.set_unsigned(
-                                instr.special3_rtype.rd,
-                                (((~0U) << 16) * ((rt.u >> 15) & 1)) |
-                                    (rt.u & 0xFFFF));
-                            break;
-                        }
-                        default: return false;
-                    }
+                    reg_file.set_unsigned(instr.special3_type_bshfl.rd, result);
 
                     break;
                 }
-                case RFunc::e_ins: {
-                    // INS, rs, rt, msb(rd), lsb(extra), func
-                    const uint32_t msb = instr.special3_rtype.rd;
-                    const uint32_t lsb = instr.special3_rtype.extra;
-                    const uint32_t size = msb - lsb + 1;
-
-                    // Error cases
-                    if (lsb >= 32 || size == 0 || size > 32 || lsb + size > 32)
-                        return false;
-
-                    // Mask out the lowest 'size' bits from rs register
-                    uint32_t mask = (size == 32) ? ~0 : (1 << size) - 1;
-                    uint32_t bitfield =
-                        reg_file.get(instr.special3_rtype.rs).u & mask;
-
-                    // Shift mask to output position and insert bitfield
-                    mask = ~(mask << lsb);
-                    const uint32_t val = (rt.u & mask) | (bitfield << lsb);
-                    reg_file.set_unsigned(instr.special3_rtype.rt, val);
+                case Func::e_wsbh: {
+                    // Word Swap Bytes Within Halfwords
+                    reg_file.set_unsigned(instr.special3_type_bshfl.rd,
+                                          ((rt.u & 0xFF) << 8) |
+                                              ((rt.u & 0xFF00) >> 8) |
+                                              ((rt.u & 0xFF0000) << 8) |
+                                              ((rt.u & 0xFF000000) >> 8));
                     break;
                 }
-                case RFunc::e_ext: {
-                    // EXT, rt, rs, msbd(rd), lsb(extra), func
-                    const uint32_t size = instr.special3_rtype.rd + 1;
-                    const uint32_t lsb = instr.special3_rtype.extra;
-
-                    // Error cases
-                    if (lsb >= 32 || size == 0 || size > 32 || lsb + size > 32)
-                        return false;
-
-                    uint32_t mask =
-                        (size == 32) ? ~0 : ((1 << size) - 1) << lsb;
-                    const uint32_t bitfield =
-                        (reg_file.get(instr.special3_rtype.rs).u & mask);
-                    reg_file.set_unsigned(instr.special3_rtype.rt,
-                                          bitfield >> lsb);
+                case Func::e_seb: {
+                    // Sign-extend Byte
+                    reg_file.set_unsigned(instr.special3_type_bshfl.rd,
+                                          (((~0U) << 8) * ((rt.u >> 7) & 1)) |
+                                              (rt.u & 0xFF));
+                    break;
+                }
+                case Func::e_seh: {
+                    // Sign-extend Halfword
+                    reg_file.set_unsigned(instr.special3_type_bshfl.rd,
+                                          (((~0U) << 16) * ((rt.u >> 15) & 1)) |
+                                              (rt.u & 0xFFFF));
                     break;
                 }
                 default: return false;
             }
+
+            return true;
+        }
+
+        template <typename RegisterFile>
+        [[nodiscard]] inline static bool
+        handle_special3_type_ext_instr(const Instruction instr,
+                                       RegisterFile& reg_file) {
+            using Register = typename RegisterFile::Register;
+
+            const Register rt = reg_file.get(instr.special3_type.rt);
+
+            const uint32_t size = instr.special3_type_ext.msbd + 1;
+            const uint32_t lsb = instr.special3_type_ext.lsb;
+
+            // Error cases
+            if (lsb >= 32 || size == 0 || size > 32 || lsb + size > 32)
+                return false;
+
+            const uint32_t mask = (size == 32) ? ~0 : ((1 << size) - 1) << lsb;
+            const uint32_t bitfield =
+                (reg_file.get(instr.special3_type.rs).u & mask);
+            reg_file.set_unsigned(instr.special3_type.rt, bitfield >> lsb);
+
+            return true;
+        }
+
+        template <typename RegisterFile>
+        [[nodiscard]] inline static bool
+        handle_special3_type_ins_instr(const Instruction instr,
+                                       RegisterFile& reg_file) {
+            using Register = typename RegisterFile::Register;
+
+            const Register rt = reg_file.get(instr.special3_type.rt);
+
+            const uint32_t msb = instr.special3_type_ins.msb;
+            const uint32_t lsb = instr.special3_type_ins.lsb;
+            const uint32_t size = msb - lsb + 1;
+
+            // Error cases
+            if (lsb >= 32 || size == 0 || size > 32 || lsb + size > 32)
+                return false;
+
+            // Mask out the lowest 'size' bits from rs register
+            uint32_t mask = (size == 32) ? ~0 : (1 << size) - 1;
+            uint32_t bitfield = reg_file.get(instr.special3_type.rs).u & mask;
+
+            // Shift mask to output position and insert bitfield
+            mask = ~(mask << lsb);
+            const uint32_t val = (rt.u & mask) | (bitfield << lsb);
+            reg_file.set_unsigned(instr.special3_type.rt, val);
 
             return true;
         }
@@ -682,8 +682,16 @@ namespace mips_emulator {
                     // TODO: Handle FPU Brach instructions
                     return false;
                 }
-                case Type::e_special3_rtype:
-                    return handle_special3_rtype_instr(instr, reg_file);
+
+                    // Special 3
+                case Type::e_special3_type_bshfl:
+                    return handle_special3_type_bshfl_instr(instr, reg_file);
+                case Type::e_special3_type_ext:
+                    return handle_special3_type_ext_instr(instr, reg_file);
+                case Type::e_special3_type_ins:
+                    return handle_special3_type_ins_instr(instr, reg_file);
+
+                    // Regimm
                 case Type::e_regimm_itype:
                     return handle_regimm_itype_instr(instr, reg_file);
 

--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -31,7 +31,9 @@ namespace mips_emulator {
             e_fpu_rtype,
             e_fpu_btype,
             e_fpu_ttype,
-            e_special3_rtype,
+            e_special3_type_bshfl,
+            e_special3_type_ext,
+            e_special3_type_ins,
             e_regimm_itype,
             e_pcrel_type1,
             e_pcrel_type2,
@@ -169,20 +171,20 @@ namespace mips_emulator {
             e_bshfl = 0b100000,
         };
 
-        // regimm function types are dependent on value in bits 16 to 20
-        enum class RegimmITypeOp : uint8_t {
-            e_bgez = 1,
-            e_bltz = 0,
-        };
-
         // Opcode enum for special3 bshfl instructions
         // Special3 instructions have a bunch of different layouts depending on
         // the func field
-        enum class Special3BSHFLTypeOp : uint8_t {
+        enum class Special3BSHFLFunc : uint8_t {
             e_bitswap = 0,
             e_wsbh = 0b00010,
             e_seh = 0b11000,
             e_seb = 0b10000,
+        };
+
+        // regimm function types are dependent on value in bits 16 to 20
+        enum class RegimmITypeOp : uint8_t {
+            e_bgez = 1,
+            e_bltz = 0,
         };
 
         // PC-relative functions
@@ -254,14 +256,37 @@ namespace mips_emulator {
         });
 
         // Special3 structs
-        // Special3RType, similar to R type instruction
-        // Calling it R-type due to lack of better name
-        // Special3 instructions have a bunch of different layouts depending on
-        // the func field
-        PACKED(struct Special3RType {
+        PACKED(struct Special3Type {
             uint32_t func : 6;
             uint32_t extra : 5;
             uint32_t rd : 5;
+            uint32_t rt : 5;
+            uint32_t rs : 5;
+            uint32_t special3 : 6;
+        });
+
+        PACKED(struct Special3TypeBSHFL {
+            uint32_t bshfl : 6;
+            uint32_t func : 5;
+            uint32_t rd : 5;
+            uint32_t rt : 5;
+            uint32_t zero : 5;
+            uint32_t special3 : 6;
+        });
+
+        PACKED(struct Special3TypeEXT {
+            uint32_t ext : 6;
+            uint32_t lsb : 5;
+            uint32_t msbd : 5;
+            uint32_t rt : 5;
+            uint32_t rs : 5;
+            uint32_t special3 : 6;
+        });
+
+        PACKED(struct Special3TypeINS {
+            uint32_t ins : 6;
+            uint32_t lsb : 5;
+            uint32_t msb : 5;
             uint32_t rt : 5;
             uint32_t rs : 5;
             uint32_t special3 : 6;
@@ -282,14 +307,14 @@ namespace mips_emulator {
             uint32_t imm : 19;
             uint32_t func : 2;
             uint32_t rs : 5;
-            uint32_t op : 6;
+            uint32_t pcrel : 6;
         });
 
         PACKED(struct PCRelType2 {
             uint32_t imm : 16;
             uint32_t func : 5;
             uint32_t rs : 5;
-            uint32_t op : 6;
+            uint32_t pcrel : 6;
         });
 
         // Make sure internal structs are the same size
@@ -308,8 +333,17 @@ namespace mips_emulator {
         static_assert(sizeof(FPUTType) == 4,
                       "Instruction::FPUTType bitfield is not 4 bytes in size");
         static_assert(
-            sizeof(Special3RType) == 4,
-            "Instruction::Special3RType bitfield is not 4 bytes in size");
+            sizeof(Special3Type) == 4,
+            "Instruction::Special3Type bitfield is not 4 bytes in size");
+        static_assert(
+            sizeof(Special3TypeBSHFL) == 4,
+            "Instruction::Special3TypeBSHFL bitfield is not 4 bytes in size");
+        static_assert(
+            sizeof(Special3TypeEXT) == 4,
+            "Instruction::Special3TypeEXT bitfield is not 4 bytes in size");
+        static_assert(
+            sizeof(Special3TypeINS) == 4,
+            "Instruction::Special3TypeINS bitfield is not 4 bytes in size");
         static_assert(
             sizeof(RegimmIType) == 4,
             "Instruction::RegimmIType bitfield is not 4 bytes in size");
@@ -399,25 +433,26 @@ namespace mips_emulator {
         // raw
         Instruction(const uint32_t value) { raw = value; }
 
-        // Special3 R-Type
-        Instruction(const Special3Func func, const Special3BSHFLTypeOp op,
+        // Special3
+        Instruction(const Special3Func func, const Special3BSHFLFunc op,
                     const RegisterName rd, const RegisterName rt) {
-            special3_rtype.func = static_cast<uint8_t>(func);
-            special3_rtype.extra = static_cast<uint8_t>(op);
-            special3_rtype.rd = static_cast<uint8_t>(rd);
-            special3_rtype.rt = static_cast<uint8_t>(rt);
-            special3_rtype.rs = 0;
-            special3_rtype.special3 = SPECIAL3_OPCODE;
+            special3_type.func = static_cast<uint8_t>(func);
+            special3_type.extra = static_cast<uint8_t>(op);
+            special3_type.rd = static_cast<uint8_t>(rd);
+            special3_type.rt = static_cast<uint8_t>(rt);
+            special3_type.rs = 0;
+            special3_type.special3 = SPECIAL3_OPCODE;
         }
+
         Instruction(const Special3Func func, const uint8_t extra,
                     const uint8_t rd, const RegisterName rs,
                     const RegisterName rt) {
-            special3_rtype.func = static_cast<uint8_t>(func);
-            special3_rtype.extra = extra;
-            special3_rtype.rd = rd;
-            special3_rtype.rs = static_cast<uint8_t>(rs);
-            special3_rtype.rt = static_cast<uint8_t>(rt);
-            special3_rtype.special3 = SPECIAL3_OPCODE;
+            special3_type.func = static_cast<uint8_t>(func);
+            special3_type.extra = extra;
+            special3_type.rd = rd;
+            special3_type.rs = static_cast<uint8_t>(rs);
+            special3_type.rt = static_cast<uint8_t>(rt);
+            special3_type.special3 = SPECIAL3_OPCODE;
         }
 
         // Regimm I-Type
@@ -432,7 +467,7 @@ namespace mips_emulator {
         // PC relative
         Instruction(const RegisterName rs, const PCRelFunc1 func,
                     const uint32_t immediate) {
-            pcrel_type1.op = PCREL_OPCODE;
+            pcrel_type1.pcrel = PCREL_OPCODE;
             pcrel_type1.rs = static_cast<uint8_t>(rs);
             pcrel_type1.func = static_cast<uint8_t>(func);
             pcrel_type1.imm = immediate;
@@ -440,7 +475,7 @@ namespace mips_emulator {
 
         Instruction(const RegisterName rs, const PCRelFunc2 func,
                     const uint16_t immediate) {
-            pcrel_type1.op = PCREL_OPCODE;
+            pcrel_type1.pcrel = PCREL_OPCODE;
             pcrel_type1.rs = static_cast<uint8_t>(rs);
             pcrel_type1.func = static_cast<uint8_t>(func);
             pcrel_type1.imm = immediate;
@@ -485,8 +520,17 @@ namespace mips_emulator {
                     return Type::e_regimm_itype;
 
                     // Special3
-                case SPECIAL3_OPCODE:
-                    return Type::e_special3_rtype;
+                case SPECIAL3_OPCODE: {
+                    switch (static_cast<Special3Func>(special3_type.func)) {
+                        case Special3Func::e_bshfl:
+                            return Type::e_special3_type_bshfl;
+                        case Special3Func::e_ext:
+                            return Type::e_special3_type_ext;
+                        case Special3Func::e_ins:
+                            return Type::e_special3_type_ins;
+                    }
+                    break;
+                }
 
                     // PC relative
                 case PCREL_OPCODE: {
@@ -522,7 +566,10 @@ namespace mips_emulator {
         FPUTType fpu_ttype;
         FPUBType fpu_btype;
 
-        Special3RType special3_rtype;
+        Special3Type special3_type;
+        Special3TypeBSHFL special3_type_bshfl;
+        Special3TypeEXT special3_type_ext;
+        Special3TypeINS special3_type_ins;
 
         RegimmIType regimm_itype;
 

--- a/tests/executor/special3.cpp
+++ b/tests/executor/special3.cpp
@@ -27,7 +27,7 @@ TEST_CASE("ext", "[Executor]") {
                                     RegisterName::e_t1, RegisterName::e_t0);
 
             const bool no_error =
-                Executor::handle_special3_rtype_instr(instr, reg_file);
+                Executor::handle_special3_type_ext_instr(instr, reg_file);
             REQUIRE(no_error);
 
             REQUIRE(reg_file.get(RegisterName::e_t0).u == test[3]);
@@ -55,7 +55,7 @@ TEST_CASE("ins", "[Executor]") {
                                     RegisterName::e_t1, RegisterName::e_t0);
 
             const bool no_error =
-                Executor::handle_special3_rtype_instr(instr, reg_file);
+                Executor::handle_special3_type_ins_instr(instr, reg_file);
             REQUIRE(no_error);
 
             REQUIRE(reg_file.get(RegisterName::e_t0).u == test[4]);
@@ -65,7 +65,7 @@ TEST_CASE("ins", "[Executor]") {
 
 TEST_CASE("bitswap", "[Executor") {
     using R = Instruction::Special3Func;
-    using BSHFLOp = Instruction::Special3BSHFLTypeOp;
+    using BSHFLOp = Instruction::Special3BSHFLFunc;
 
     SECTION("swaps") {
         uint32_t cases[][2] = {{0, 0},
@@ -86,7 +86,7 @@ TEST_CASE("bitswap", "[Executor") {
                                     RegisterName::e_t0, RegisterName::e_t1);
 
             const bool no_error =
-                Executor::handle_special3_rtype_instr(instr, reg_file);
+                Executor::handle_special3_type_bshfl_instr(instr, reg_file);
             REQUIRE(no_error);
 
             REQUIRE(reg_file.get(RegisterName::e_t0).u == test[1]);
@@ -96,7 +96,7 @@ TEST_CASE("bitswap", "[Executor") {
 
 TEST_CASE("wsbh", "[Executor]") {
     using R = Instruction::Special3Func;
-    using BSHFLOp = Instruction::Special3BSHFLTypeOp;
+    using BSHFLOp = Instruction::Special3BSHFLFunc;
 
     SECTION("Swapping") {
         RegisterFile reg_file;
@@ -108,7 +108,7 @@ TEST_CASE("wsbh", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0x00FF00FF);
@@ -124,7 +124,7 @@ TEST_CASE("wsbh", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0);
@@ -140,7 +140,7 @@ TEST_CASE("wsbh", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == ~0U);
@@ -149,7 +149,7 @@ TEST_CASE("wsbh", "[Executor]") {
 
 TEST_CASE("seh", "[Executor]") {
     using R = Instruction::Special3Func;
-    using BSHFLOp = Instruction::Special3BSHFLTypeOp;
+    using BSHFLOp = Instruction::Special3BSHFLFunc;
 
     SECTION("Leading 1") {
         RegisterFile reg_file;
@@ -160,7 +160,7 @@ TEST_CASE("seh", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0xFFFFF0F0);
@@ -175,7 +175,7 @@ TEST_CASE("seh", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0x7ff1);
@@ -184,7 +184,7 @@ TEST_CASE("seh", "[Executor]") {
 
 TEST_CASE("seb", "[Executor]") {
     using R = Instruction::Special3Func;
-    using BSHFLOp = Instruction::Special3BSHFLTypeOp;
+    using BSHFLOp = Instruction::Special3BSHFLFunc;
 
     SECTION("Leading 1") {
         RegisterFile reg_file;
@@ -195,7 +195,7 @@ TEST_CASE("seb", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0xFFFFFFF8);
@@ -210,7 +210,7 @@ TEST_CASE("seb", "[Executor]") {
                                 RegisterName::e_t1);
 
         const bool no_error =
-            Executor::handle_special3_rtype_instr(instr, reg_file);
+            Executor::handle_special3_type_bshfl_instr(instr, reg_file);
         REQUIRE(no_error);
 
         REQUIRE(reg_file.get(RegisterName::e_t0).u == 0x0000007F);

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -215,67 +215,68 @@ TEST_CASE("FPU B Type", "[Instruction]") {
 
 TEST_CASE("Special3 Type", "[Instruction]") {
     using Type = Instruction::Type;
-    using R = Instruction::Special3Func;
-    using ROp = Instruction::Special3BSHFLTypeOp;
+    using Func = Instruction::Special3Func;
+    using BSHFLFunc = Instruction::Special3BSHFLFunc;
 
     SECTION("get_type ext") {
         // EXT, rt, rs, msbd(rd), lsb(extra), func
-        const auto inst =
-            Instruction(R::e_ext, 0, 1, RegisterName::e_t0, RegisterName::e_t1);
-        REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
+        const auto inst = Instruction(Func::e_ext, 0, 1, RegisterName::e_t0,
+                                      RegisterName::e_t1);
+        REQUIRE(instr_type_matches(inst, Type::e_special3_type_ext));
     }
 
     // Note, the size parameter is stored as size-1 in the machine instruction
     SECTION("ext $t0 $t1 0 1") {
-        Instruction inst(R::e_ext, 0, 0, RegisterName::e_t1,
+        Instruction inst(Func::e_ext, 0, 0, RegisterName::e_t1,
                          RegisterName::e_t0);
         REQUIRE(inst.raw == 0x7D280000);
     }
 
     SECTION("get_type ins") {
         // INS, rt, rs, msb(rd), lsb(extra), func
-        const auto inst =
-            Instruction(R::e_ins, 0, 0, RegisterName::e_t0, RegisterName::e_t1);
-        REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
+        const auto inst = Instruction(Func::e_ins, 0, 0, RegisterName::e_t0,
+                                      RegisterName::e_t1);
+        REQUIRE(instr_type_matches(inst, Type::e_special3_type_ins));
     }
 
     // Note, the size parameter is stored as size-1 in the machine instruction
     SECTION("ins $t0 $t1 0 1") {
-        Instruction inst(R::e_ins, 0, 0, RegisterName::e_t1,
+        Instruction inst(Func::e_ins, 0, 0, RegisterName::e_t1,
                          RegisterName::e_t0);
         REQUIRE(inst.raw == 0x7D280004);
     }
 
     SECTION("get_type bshfl") {
-        ROp instr[] = {ROp::e_bitswap, ROp::e_wsbh, ROp::e_seb, ROp::e_seh};
+        BSHFLFunc instr[] = {BSHFLFunc::e_bitswap, BSHFLFunc::e_wsbh,
+                             BSHFLFunc::e_seb, BSHFLFunc::e_seh};
 
         for (auto const v : instr) {
-            const auto inst = Instruction(R::e_bshfl, v, RegisterName::e_t0,
+            const auto inst = Instruction(Func::e_bshfl, v, RegisterName::e_t0,
                                           RegisterName::e_t1);
-            REQUIRE(instr_type_matches(inst, Type::e_special3_rtype));
+            REQUIRE(instr_type_matches(inst, Type::e_special3_type_bshfl));
         }
     }
 
     SECTION("bitswap $t0 $t1") {
-        Instruction t(R::e_bshfl, ROp::e_bitswap, RegisterName::e_t0,
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_bitswap, RegisterName::e_t0,
                       RegisterName::e_t1);
         REQUIRE(t.raw == 0x7C094020);
     }
 
     SECTION("wsbh $t0 $t1") {
-        Instruction t(R::e_bshfl, ROp::e_wsbh, RegisterName::e_t0,
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_wsbh, RegisterName::e_t0,
                       RegisterName::e_t1);
         REQUIRE(t.raw == 0x7c0940a0);
     }
 
     SECTION("seb $t0 $t1") {
-        Instruction t(R::e_bshfl, ROp::e_seb, RegisterName::e_t0,
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_seb, RegisterName::e_t0,
                       RegisterName::e_t1);
         REQUIRE(t.raw == 0x7c094420);
     }
 
     SECTION("seh $t0 $t1") {
-        Instruction t(R::e_bshfl, ROp::e_seh, RegisterName::e_t0,
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_seh, RegisterName::e_t0,
                       RegisterName::e_t1);
         REQUIRE(t.raw == 0x7c094620);
     }


### PR DESCRIPTION
The special 3 instruction layout and handling was cleaned up. It was split up into BSHFL, EXT and INS. New bitfields inside of the Instruction union were created alongside handlers in the executor.