### PR TITLE
Added align instruction.

### DIFF
--- a/include/mips-emulator/executor.hpp
+++ b/include/mips-emulator/executor.hpp
@@ -447,6 +447,30 @@ namespace mips_emulator {
                                               ((rt.u & 0xFF000000) >> 8));
                     break;
                 }
+                case Func::e_align_0:
+                case Func::e_align_1:
+                case Func::e_align_2:
+                case Func::e_align_3: {
+                    // Concatenates two GPR's, and extracts a contiguous subset
+                    // at a byte position
+
+                    // Align is a special case were the func field is in reality
+                    // 3 bits and the byte position is stored in the remaining 2
+                    // lower bits
+                    const uint8_t bp = (instr.special3_type_bshfl.func & 0x3);
+
+                    const Register rs =
+                        reg_file.get(instr.special3_type_bshfl.rs);
+
+                    // With bp = 0 align should act like a rd = rt register
+                    // move, however right shifting by 32 doesn't return 0 so
+                    // doing this
+                    const auto lo = (bp == 0) ? 0 : (rs.u >> (8 * (4 - bp)));
+
+                    reg_file.set_unsigned(instr.special3_type_bshfl.rd,
+                                          (rt.u << (8 * bp)) | lo);
+                    break;
+                }
                 case Func::e_seb: {
                     // Sign-extend Byte
                     reg_file.set_unsigned(instr.special3_type_bshfl.rd,

--- a/include/mips-emulator/instruction.hpp
+++ b/include/mips-emulator/instruction.hpp
@@ -172,11 +172,16 @@ namespace mips_emulator {
         };
 
         // Opcode enum for special3 bshfl instructions
-        // Special3 instructions have a bunch of different layouts depending on
-        // the func field
+        // Note: Align is special case with the func field being replaced with a
+        // 3 bits op and 2 bit bp instead Special3 instructions have a bunch of
+        // different layouts depending on the func field
         enum class Special3BSHFLFunc : uint8_t {
             e_bitswap = 0,
             e_wsbh = 0b00010,
+            e_align_0 = 0b01000,
+            e_align_1 = 0b01001,
+            e_align_2 = 0b01010,
+            e_align_3 = 0b01011,
             e_seh = 0b11000,
             e_seb = 0b10000,
         };
@@ -270,7 +275,7 @@ namespace mips_emulator {
             uint32_t func : 5;
             uint32_t rd : 5;
             uint32_t rt : 5;
-            uint32_t zero : 5;
+            uint32_t rs : 5;
             uint32_t special3 : 6;
         });
 
@@ -441,6 +446,17 @@ namespace mips_emulator {
             special3_type.rd = static_cast<uint8_t>(rd);
             special3_type.rt = static_cast<uint8_t>(rt);
             special3_type.rs = 0;
+            special3_type.special3 = SPECIAL3_OPCODE;
+        }
+
+        Instruction(const Special3Func func, const Special3BSHFLFunc op,
+                    const RegisterName rd, const RegisterName rs,
+                    const RegisterName rt) {
+            special3_type.func = static_cast<uint8_t>(func);
+            special3_type.extra = static_cast<uint8_t>(op);
+            special3_type.rd = static_cast<uint8_t>(rd);
+            special3_type.rt = static_cast<uint8_t>(rt);
+            special3_type.rs = static_cast<uint8_t>(rs);
             special3_type.special3 = SPECIAL3_OPCODE;
         }
 

--- a/tests/executor/special3.cpp
+++ b/tests/executor/special3.cpp
@@ -147,6 +147,43 @@ TEST_CASE("wsbh", "[Executor]") {
     }
 }
 
+TEST_CASE("align", "[Executor") {
+    using R = Instruction::Special3Func;
+    using BSHFLOp = Instruction::Special3BSHFLFunc;
+
+    SECTION("aligns") {
+        uint32_t cases[][4] = {
+            {0x87654321, 0x12345678, static_cast<uint32_t>(BSHFLOp::e_align_0),
+             0x87654321},
+            {0x11111111, 0x22222222, static_cast<uint32_t>(BSHFLOp::e_align_2),
+             0x11112222},
+            {0x12345678, 0x87654321, static_cast<uint32_t>(BSHFLOp::e_align_3),
+             0x78876543},
+            {0x00000000, 0xffffffff, static_cast<uint32_t>(BSHFLOp::e_align_1),
+             0x000000ff},
+            {0xffffffff, 0x00000000, static_cast<uint32_t>(BSHFLOp::e_align_3),
+             0xff000000}};
+
+        for (auto& test : cases) {
+            RegisterFile reg_file;
+
+            reg_file.set_unsigned(RegisterName::e_t0, 0);
+            reg_file.set_unsigned(RegisterName::e_t1, test[0]);
+            reg_file.set_unsigned(RegisterName::e_t2, test[1]);
+
+            const Instruction instr(R::e_bshfl, static_cast<BSHFLOp>(test[2]),
+                                    RegisterName::e_t0, RegisterName::e_t2,
+                                    RegisterName::e_t1);
+
+            const bool no_error =
+                Executor::handle_special3_type_bshfl_instr(instr, reg_file);
+            REQUIRE(no_error);
+
+            REQUIRE(reg_file.get(RegisterName::e_t0).u == test[3]);
+        }
+    }
+}
+
 TEST_CASE("seh", "[Executor]") {
     using R = Instruction::Special3Func;
     using BSHFLOp = Instruction::Special3BSHFLFunc;

--- a/tests/instruction.cpp
+++ b/tests/instruction.cpp
@@ -280,6 +280,18 @@ TEST_CASE("Special3 Type", "[Instruction]") {
                       RegisterName::e_t1);
         REQUIRE(t.raw == 0x7c094620);
     }
+
+    SECTION("get_type align") {
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_align_1, RegisterName::e_t0,
+                      RegisterName::e_t2, RegisterName::e_t1);
+        REQUIRE(instr_type_matches(t, Type::e_special3_type_bshfl));
+    }
+
+    SECTION("align $t0 $t1 $t2 1") {
+        Instruction t(Func::e_bshfl, BSHFLFunc::e_align_1, RegisterName::e_t0,
+                      RegisterName::e_t1, RegisterName::e_t2);
+        REQUIRE(t.raw == 0x7d2a4260);
+    }
 }
 
 TEST_CASE("Regimm I Type", "[Instruction]") {


### PR DESCRIPTION
Closes #20.

Align is a special case of the bshfl instructions with the bshfl.func split into a 3 bit func and a 2 bit bp, and also a non zero rs field.